### PR TITLE
Fix a couple of broken links

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ permalink: index.html  # Is the only page that doesn't follow the pattern /:path
 
 This course aims to teach a **core set** of established, intermediate-level software development skills and
 best practices for working as part of a team in a research environment using Python as an
-example programming language (see detailed [learning objectives](/index.html#learning-objectives-for-the-workshop) below).
+example programming language (see detailed [learning objectives](index.html#learning-objectives-for-the-workshop) below).
 The core set of skills we teach is not a comprehensive set of all-encompassing skills,
 but a selective set of tried-and-tested collaborative development skills that forms a firm foundation for continuing
 on your learning journey.
@@ -45,7 +45,7 @@ currently undocumented or unstructured
  - You have learned the basics of writing software but have not
  applied that knowledge yet (or are unsure how to apply it) to your work. In this case, we suggest you revisit the course
  after you have been programming for at least 6 months
- - You are well familiar with the [learning objectives of the course](/index.html#learning-objectives-for-the-workshop) and those of individual episodes
+ - You are well familiar with the [learning objectives of the course](index.html#learning-objectives-for-the-workshop) and those of individual episodes
  - The software you write is fully documented and well architected
 
 > ## Prerequisites


### PR DESCRIPTION
The links to the learning objectives were 404'ing as they resolve to https://ukaea-rse-training.github.io/index.html#learning-objectives-for-the-workshop and not
https://ukaea-rse-training.github.io/python-intermediate-development/#learning-objectives-for-the-workshop (the latter being the anchor for that section).

Removing the trailing slash should fix this as compared with the relative path link to quiz/index.html.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
